### PR TITLE
Allow Override of IP for blue/green

### DIFF
--- a/wait.py
+++ b/wait.py
@@ -6,9 +6,22 @@ from time import sleep
 
 import requests
 from requests import RequestException
+from urllib3.util import connection
+import socket
 
 requests_session = requests.Session()
 
+def patched_create_connection(address, *args, **kwargs):
+    host, port = address
+    hostname = overrideResolver(host,)
+
+    return _orig_create_connection((hostname, port), *args, **kwargs)
+
+def overrideResolver(host): 
+    if os.getenv("OVERRIDE_IP") and host.endswith('.' + os.getenv("DOMAIN")):
+        return os.getenv("OVERRIDE_IP")
+    
+    return socket.gethostbyname(host)
 
 def is_up(auth):
     url = os.getenv("URL")
@@ -42,6 +55,11 @@ def is_on_commit(auth, commit):
 
 def retry_until_healthy(auth, timeout, retries, commit_id):
     for i in range(0, retries):
+        if os.getenv("OVERRIDE_IP"):
+            print(f'WARNING: DNS queries overriden to use IP {os.getenv("OVERRIDE_IP")}')
+
+            
+
         on_commit = is_on_commit(auth, commit_id)
         up = is_up(auth)
         if on_commit and up:
@@ -51,10 +69,17 @@ def retry_until_healthy(auth, timeout, retries, commit_id):
         sleep(timeout)
 
 
+_orig_create_connection = connection.create_connection
+connection.create_connection = patched_create_connection
+
 if __name__ == '__main__':
     if not os.getenv("URL") or not os.getenv("COMMIT"):
         print('Set environment variables URL and COMMIT')
         exit(1)
+
+    if not os.getenv("DOMAIN") and os.getenv("OVERRIDE_IP"):
+        print('Environment variable OVERRIDE_IP also requires environment variable DOMAIN')
+        exit(2)
 
     if not strtobool(os.getenv("SSL_VERIFY", "True")):
         requests_session.verify = False

--- a/wait.py
+++ b/wait.py
@@ -13,8 +13,7 @@ requests_session = requests.Session()
 
 def patched_create_connection(address, *args, **kwargs):
     host, port = address
-    hostname = overrideResolver(host,)
-
+    hostname = overrideResolver(host)
     return _orig_create_connection((hostname, port), *args, **kwargs)
 
 def overrideResolver(host): 
@@ -58,7 +57,7 @@ def retry_until_healthy(auth, timeout, retries, commit_id):
         if os.getenv("OVERRIDE_IP"):
             print(f'WARNING: DNS queries overriden to use IP {os.getenv("OVERRIDE_IP")}')
 
-            
+
 
         on_commit = is_on_commit(auth, commit_id)
         up = is_up(auth)


### PR DESCRIPTION
This PR allows us to supply two env vars `OVERRIDE_IP` and `DOMAIN` to override all DNS lookups in the domain `DOMAIN` to return the IP address in `OVERRIDE_IP`.

Some examples:

```bash
#Normal usage
$SSL_VERIFY=false COMMIT=b155bf1 URL=https://docs.hls-pre.forgerock.financial/external python3 ./wait.py
expected_commit=b155bf1 server_commit=b155bf1
status=UP
Service is up

# supply IP but not DOMAIN
$ OVERRIDE_IP=127.0.0.1 SSL_VERIFY=false COMMIT=b155bf1 URL=https://docs.hls-pre.forgerock.financial/external python3 ./wait.py
Environment variable OVERRIDE_IP also requires environment variable DOMAIN

# Supply the wrong IP
$ OVERRIDE_IP=127.0.0.1 DOMAIN=hls-pre.forgerock.financial SSL_VERIFY=false COMMIT=b155bf1 URL=https://docs.hls-pre.forgerock.financial/external python3 ./wait.py
WARNING: DNS queries overriden to use IP 127.0.0.1
Waiting timeout=1

# RIGHT IP and DOMAIN, now commit needs changing
$ OVERRIDE_IP=35.204.230.8 DOMAIN=hls-pre.forgerock.financial SSL_VERIFY=false COMMIT=b155bf1 URL=https://docs.hls-pre.forgerock.financial/external python3 ./wait.py
WARNING: DNS queries overriden to use IP 35.204.230.8
expected_commit=b155bf1 server_commit=f4fd37d
status=UP
Waiting timeout=1

# use the right commit
$  SSL_VERIFY=false OVERRIDE_IP=35.204.230.8 DOMAIN=hls-pre.forgerock.financial COMMIT=f4fd37d URL=https://docs.hls-pre.forgerock.financial/external python3 ./wait.py
WARNING: DNS queries overriden to use IP 35.204.230.8
expected_commit=f4fd37d server_commit=f4fd37d
status=UP
Service is up

```